### PR TITLE
[SWP-4029] - Remove `Accept-Encoding: None` default client header.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,6 @@ cache:
   directories:
   - node_modules
 
-after_success:
-- bash <(curl -s https://codecov.io/bash)
-
 script:
 - npm run build
 - npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-point/typescript",
-  "version": "1.3.3-alpha.0",
+  "version": "1.3.3",
   "description": "A TypeScript library.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pod-point/typescript",
-  "version": "1.3.2",
+  "version": "1.3.3-alpha.0",
   "description": "A TypeScript library.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",

--- a/src/__tests__/http/Client.test.ts
+++ b/src/__tests__/http/Client.test.ts
@@ -22,7 +22,6 @@ describe('Client', () => {
             baseURL: fakeDomain + fakePrefix,
             headers: {
                 'Accept': 'application/json',
-                'Accept-Encoding': 'None',
                 'Content-Type': 'application/json',
                 'User-Agent': fakeUserAgent,
             },

--- a/src/http/Client.ts
+++ b/src/http/Client.ts
@@ -15,7 +15,6 @@ export default class Client implements ClientInterface {
             baseURL: domain + prefix,
             headers: {
                 'Accept': 'application/json',
-                'Accept-Encoding': 'None',
                 'Content-Type': 'application/json',
                 'User-Agent': userAgent,
             },


### PR DESCRIPTION
Prevent overriding the Accept-Encoding header, thereby allowing this is be set automatically by the consuming application - which in our case, RN, this will be set to `gzip, br` enabling compression from the server.